### PR TITLE
Move the 'mean' calculation to before the pct_threshold adjustments

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ A network daemon for aggregating statistics (counters and timers), rolling them 
 Create config.yml to your liking. There are 2 flush protocols: graphite and mongo. The former simply sends to carbon every flush interval. The latter flushes to MongoDB capped collections for 10s and 1min intervals.
 
 Example config.yml
+
     ---
     bind: 127.0.0.1
     port: 8125

--- a/lib/statsd/graphite.rb
+++ b/lib/statsd/graphite.rb
@@ -35,7 +35,6 @@ module Statsd
         
         # store counters
         counters.each_pair do |key,value|
-          value /= flush_interval
           message = "stats.#{key} #{value} #{ts}\n"
           stat_string += message
           counters[key] = 0

--- a/lib/statsd/graphite.rb
+++ b/lib/statsd/graphite.rb
@@ -55,14 +55,14 @@ module Statsd
             max_at_threshold = max
 
             if (count > 1)
+              # average all the timing data
+              sum = values.inject( 0 ) { |s,x| s+x }
+              mean = sum / values.count
+
               # strip off the top 100-threshold
               threshold_index = (((100 - pct_threshold) / 100.0) * count).round
               values = values[0..-threshold_index]
               max_at_threshold = values.last
-
-              # average the remaining timings
-              sum = values.inject( 0 ) { |s,x| s+x }
-              mean = sum / values.count
             end
 
             message = ""


### PR DESCRIPTION
This commit fixes an error in the calculation of the mean data.  The mean needs to consider all data points, rather than just the first 90% of them.
