### PR TITLE
adding gauge support

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,12 @@ Sampling
 
 Tells StatsD that this counter is being sent sampled ever 1/10th of the time.
 
+Gauges
+------
+
+    gaugor:333|g
+
+StatsD now also supports gauges, arbitrary values, which can be recorded.
 
 Guts
 ----

--- a/lib/statsd.rb
+++ b/lib/statsd.rb
@@ -37,6 +37,16 @@ module Statsd
       send_stats(stats.map { |s| "#{s}:#{delta}|c" }, sample_rate)
     end
   
+    # +stats+ is a hash
+    def gauge(stats)
+      send_stats(stats.map { |s,val|
+                   if @prefix
+                     s = "#{@prefix}.#{s}"
+                   end
+                   "#{s}:#{val}|g"
+                 })
+    end
+
     private
   
     def send_stats(data, sample_rate = 1)

--- a/lib/statsd/graphite.rb
+++ b/lib/statsd/graphite.rb
@@ -37,7 +37,6 @@ module Statsd
         gauges.each_pair do |key,value|
           message = "stats.gauges.#{key} #{value} #{ts}\n"
           stat_string += message
-          gauges[key] = 0
 
           num_stats += 1
         end

--- a/lib/statsd/graphite.rb
+++ b/lib/statsd/graphite.rb
@@ -2,7 +2,7 @@ require 'benchmark'
 require 'eventmachine'
 module Statsd
   class Graphite < EM::Connection
-    attr_accessor :counters, :timers, :flush_interval
+    attr_accessor :counters, :timers, :gauges, :flush_interval
     
     def initialize(*args)
       puts args
@@ -27,12 +27,21 @@ module Statsd
     # end
           
     def flush_stats
-      print "#{Time.now} Flushing #{counters.count} counters and #{timers.count} timers to Graphite."
+      print "#{Time.now} Flushing #{gauges.count} gauges, #{counters.count} counters and #{timers.count} timers to Graphite."
       stat_string = ''
       time = ::Benchmark.realtime do
         ts = Time.now.to_i
         num_stats = 0        
         
+        # store gauges
+        gauges.each_pair do |key,value|
+          message = "stats.gauges.#{key} #{value} #{ts}\n"
+          stat_string += message
+          gauges[key] = 0
+
+          num_stats += 1
+        end
+
         # store counters
         counters.each_pair do |key,value|
           message = "stats.#{key} #{value} #{ts}\n"

--- a/lib/statsd/server.rb
+++ b/lib/statsd/server.rb
@@ -20,7 +20,6 @@ module Statsd
       gauges = GAUGES.dup
       COUNTERS.clear
       TIMERS.clear
-      GAUGES.clear
       [counters,timers,gauges]
     end
 
@@ -45,7 +44,7 @@ module Statsd
             COUNTERS[key] ||= 0
             COUNTERS[key] += (fields[0].to_i || 1) * (1.0 / sample_rate.to_f)
           elsif (fields[1].strip == "g")
-            GAUGES[key] ||= (fields[0].to_i || 0)
+            GAUGES[key] = (fields[0].to_i || 0)
           else
             print "Invalid statistic #{fields.inspect} received; ignoring"
           end


### PR DESCRIPTION
- based on https://github.com/lookout/statsd
  initial implementation
- prefix set to `stats.gauges` as in the "canonical" (etsy)
  implementation.
  see https://github.com/etsy/statsd/blob/master/backends/graphite.js#L196
