### PR TITLE
Remove Rails dependencies

### DIFF
--- a/lib/statsd.rb
+++ b/lib/statsd.rb
@@ -1,4 +1,7 @@
 # encoding: utf-8
+
+require 'socket'
+
 module Statsd
 
   #
@@ -75,7 +78,7 @@ module Statsd
       rescue Exception => e # silent but deadly
         puts e.message
       ensure
-        sock.try(:close)
+        sock.close unless sock.nil?
       end
       true
     end


### PR DESCRIPTION
Statsd::Client has a few Rails specific bits in it, and I get exceptions when running it outside of Rails.  Specifically Object#try throws a NoSuchMethod error, and 'socket' is not normally required everywhere.
